### PR TITLE
Fix: Missing highlight style

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -335,3 +335,29 @@ button:hover {
 .nav-folder-children .nav-file-title.is-active {
   opacity: 1;
 }
+
+/* Side bar (Search Result) Highlight Fix */
+
+.search-result-file-matched-text {
+  background-color: var(--text-highlight-bg);
+  color: var(--text-highlight) !important;
+}
+
+.search-result-file-match.tappable:hover {
+  background-color: rgba(0,0,0,0.07);
+}
+
+/* Theme search result highlight fix */
+
+.suggestion-highlight {
+  background-color: var(--text-highlight-bg);
+  color: var(--text-highlight) !important;
+}
+
+/* Flashing text highlight fix*/
+
+.is-flashing {
+  background-color: var(--text-highlight-bg);
+  color: var(--text-highlight) !important;
+  border-radius: 0;
+}


### PR DESCRIPTION
## Fix: Missing highlight style

Hello,

First of all, thank you for your great work on the Obsidian Mono High Contrast theme. I’ve been using it regularly and really appreciate its clarity and aesthetics.

While using the theme, I noticed that selected text (highlighted text) did not have a defined CSS style in certain contexts, which made it a bit difficult to read. To improve usability, I made a small fix by adding appropriate styles for the selected text color and background.

I've attached before-and-after screenshots below for reference.

Please let me know if there's anything that should be adjusted or improved in this PR.  
Thanks again for the wonderful theme — I truly enjoy using it.

## Changes

### Before

<img width="807" alt="스크린샷 2025-06-07 오후 4 15 29" src="https://github.com/user-attachments/assets/eeed3c02-cef4-4bf4-86f1-d6567d576ca6" />
<img width="807" alt="스크린샷 2025-06-07 오후 4 15 50" src="https://github.com/user-attachments/assets/d906d40b-6324-45f2-8404-c56c6091b37c" />
<img width="807" alt="스크린샷 2025-06-07 오후 4 16 21" src="https://github.com/user-attachments/assets/aec46815-0d96-4b69-8177-5870ed5479db" />

### After

<img width="786" alt="스크린샷 2025-06-07 오후 4 23 05" src="https://github.com/user-attachments/assets/87213e1f-c99b-4cb7-b2e3-85828ffa2125" />
<img width="786" alt="스크린샷 2025-06-07 오후 4 23 22" src="https://github.com/user-attachments/assets/0fa31866-337a-4305-93f0-c06dc702a500" />
